### PR TITLE
Integration of AWS S3

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -48,8 +48,14 @@ object Build extends Build {
     settings = buildSettings ++ Seq(libraryDependencies ++= deps) ++ spray
   ).dependsOn(spray_aws)
 
+  val spray_s3 = Project(
+    id = "spray-s3",
+    base = file("spray-s3"),
+    settings = buildSettings ++ Seq(libraryDependencies ++= deps) ++ spray
+  ).dependsOn(spray_aws)
 
-  val root = Project(id = "spray-aws-project", base = file("."), settings = buildSettings ++ parentSettings).aggregate(spray_aws,spray_dynamodb,spray_kinesis,spray_sqs,spray_route53)
+
+  val root = Project(id = "spray-aws-project", base = file("."), settings = buildSettings ++ parentSettings).aggregate(spray_aws,spray_dynamodb,spray_kinesis,spray_sqs,spray_route53,spray_s3)
 
 
 

--- a/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
+++ b/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
@@ -110,7 +110,7 @@ abstract class SprayAWSClient(props: SprayAWSClientProps) {
     var path: String = awsReq.getResourcePath
     if (path == "" || path == null) path = "/"
     val request = if (awsReq.getContent != null) {
-      val body = awsReq.getContent.asInstanceOf[StringInputStream].getString
+      val body: Array[Byte] = Stream.continually(awsReq.getContent).takeWhile(-1 != _).map(_.toByte).toArray
       val mediaType = MediaType.custom(contentType.getOrElse(defaultContentType))
       HttpRequest(awsReq.getHttpMethod, path, headers(awsReq), HttpEntity(mediaType, body), `HTTP/1.1`)
     } else {

--- a/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
+++ b/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
@@ -110,7 +110,7 @@ abstract class SprayAWSClient(props: SprayAWSClientProps) {
     var path: String = awsReq.getResourcePath
     if (path == "" || path == null) path = "/"
     val request = if (awsReq.getContent != null) {
-      val body: Array[Byte] = Stream.continually(awsReq.getContent).takeWhile(-1 != _).map(_.toByte).toArray
+      val body: Array[Byte] = Stream.continually(awsReq.getContent.read).takeWhile(-1 != _).map(_.toByte).toArray
       val mediaType = MediaType.custom(contentType.getOrElse(defaultContentType))
       HttpRequest(awsReq.getHttpMethod, path, headers(awsReq), HttpEntity(mediaType, body), `HTTP/1.1`)
     } else {

--- a/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
+++ b/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
@@ -134,7 +134,7 @@ abstract class SprayAWSClient(props: SprayAWSClientProps) {
     awsResp.setContent(new StringInputStream(response.entity.asString))
     awsResp.setStatusCode(response.status.intValue)
     awsResp.setStatusText(response.status.defaultMessage)
-    if (awsResp.getStatusCode == 200 || awsResp.getStatusCode == 201) {
+    if (200 <= awsResp.getStatusCode && awsResp.getStatusCode < 300) {
       val handle: AmazonWebServiceResponse[T] = handler.handle(awsResp)
       val resp = handle.getResult
       Right(resp)

--- a/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
+++ b/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
@@ -1,0 +1,15 @@
+package com.sclasen.spray.aws.s3
+
+import akka.actor.{ ActorRefFactory, ActorSystem }
+
+import com.sclasen.spray.aws._
+
+case class S3ClientProps(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://s3.amazonaws.com") extends SprayAWSClientProps {
+  val service = "s3"
+}
+
+class S3Client {
+
+
+
+}

--- a/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
+++ b/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
@@ -1,15 +1,144 @@
 package com.sclasen.spray.aws.s3
 
+import java.util.{ List => JList }
+import java.io.ByteArrayInputStream
+import scala.concurrent.Future
+import scala.collection.JavaConverters._
+
+import akka.util.Timeout
 import akka.actor.{ ActorRefFactory, ActorSystem }
+
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.http.HttpResponseHandler
+import com.amazonaws.services.s3.model._
+import com.amazonaws.services.s3.model.transform.Unmarshallers
+import com.amazonaws.services.s3.internal.{ S3ErrorResponseHandler, S3ObjectResponseHandler, S3MetadataResponseHandler }
 
 import com.sclasen.spray.aws._
 
-case class S3ClientProps(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://s3.amazonaws.com") extends SprayAWSClientProps {
+case class S3ClientProps(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem,
+  factory: ActorRefFactory, endpoint: String = "https://s3.amazonaws.com")
+    extends SprayAWSClientProps {
   val service = "s3"
 }
 
-class S3Client {
+object MarshallersAndUnmarshallers {
 
+  import com.amazonaws.transform.{ Marshaller, Unmarshaller }
+  import com.amazonaws.{ DefaultRequest, Request }
+  import com.amazonaws.services.s3.internal.{ Constants, S3XmlResponseHandler }
+  import com.amazonaws.{ AmazonWebServiceRequest, AmazonWebServiceResponse }
+  import com.amazonaws.http.HttpMethodName
 
+  class S3Marshaller[X <: AmazonWebServiceRequest](httpMethod: HttpMethodName)
+      extends Marshaller[Request[X], X] {
+    def marshall(originalRequest: X): Request[X] = {
+      val request = new DefaultRequest[X](originalRequest, Constants.S3_SERVICE_NAME)
+      request.setHttpMethod(httpMethod)
+      request.addHeader("x-amz-content-sha256", "required")
 
+      originalRequest.getClass.getMethods.find(_.getName == "getBucketName").map { method =>
+        val bucketName = method.invoke(originalRequest)
+        request.setResourcePath(s"/${bucketName}/")
+
+        originalRequest.getClass.getMethods.find(_.getName == "getKey").map { method =>
+          val key = method.invoke(originalRequest)
+          request.setResourcePath(s"/${bucketName}/${key}")
+        }
+      }
+
+      request
+    }
+  }
+
+  implicit val listBucketsM = new S3Marshaller[ListBucketsRequest](HttpMethodName.GET)
+  implicit val listBucketsU = new S3XmlResponseHandler[JList[Bucket]](new Unmarshallers.ListBucketsUnmarshaller)
+
+  implicit val createBucketM = new S3Marshaller[CreateBucketRequest](HttpMethodName.PUT)
+  implicit val deleteBucketM = new S3Marshaller[DeleteBucketRequest](HttpMethodName.DELETE)
+
+  implicit val putObjectM = new S3Marshaller[PutObjectRequest](HttpMethodName.PUT) {
+    override def marshall(putObject: PutObjectRequest): Request[PutObjectRequest] = {
+      val request = super.marshall(putObject)
+
+      if (Option(putObject.getFile).isDefined) {
+        throw new Exception("File upload not supported")
+      } else {
+        request.setContent(putObject.getInputStream)
+        request
+      }
+    }
+  }
+  implicit val putObjectU = new S3MetadataResponseHandler()
+  implicit val getObjectM = new S3Marshaller[GetObjectRequest](HttpMethodName.GET)
+  implicit val deleteObjectM = new S3Marshaller[DeleteObjectRequest](HttpMethodName.DELETE)
+
+  implicit val listObjectsM = new S3Marshaller[ListObjectsRequest](HttpMethodName.GET) {
+    override def marshall(listObjects: ListObjectsRequest): Request[ListObjectsRequest] = {
+      val request = super.marshall(listObjects)
+
+      Option(listObjects.getPrefix).map { prefix =>
+        request.addParameter("prefix", prefix)
+      }
+
+      Option(listObjects.getMarker).map { marker =>
+        request.addParameter("marker", marker)
+      }
+
+      Option(listObjects.getDelimiter).map { delimiter =>
+        request.addParameter("delimiter", delimiter)
+      }
+
+      Option(listObjects.getMaxKeys).map { maxKeys =>
+        request.addParameter("max-keys", maxKeys.toString)
+      }
+
+      Option(listObjects.getEncodingType).map { encodingType =>
+        request.addParameter("encoding-type", encodingType)
+      }
+
+      request
+    }
+  }
+
+  implicit val listObjectsU = new S3XmlResponseHandler[ObjectListing](new Unmarshallers.ListObjectsUnmarshaller)
+
+  implicit val objectU = new S3ObjectResponseHandler()
+  implicit val voidU = new S3XmlResponseHandler[Unit](null)
+}
+
+class S3Client(val props: S3ClientProps) extends SprayAWSClient(props) {
+
+  import MarshallersAndUnmarshallers._
+
+  val log = props.system.log
+  def errorResponseHandler = new S3ErrorResponseHandler
+
+  def listBuckets(aws: ListBucketsRequest): Future[Either[AmazonServiceException, Seq[Bucket]]] = {
+    pipeline(request(aws)).map(response[JList[Bucket]]).map(_.right.map(_.asScala.toSeq))
+  }
+
+  def createBucket(aws: CreateBucketRequest): Future[Either[AmazonServiceException, Unit]] = {
+    pipeline(request(aws)).map(response[Unit])
+  }
+
+  def deleteBucket(aws: DeleteBucketRequest): Future[Either[AmazonServiceException, Unit]] = {
+    pipeline(request(aws)).map(response[Unit])
+  }
+
+  def putObject(aws: PutObjectRequest): Future[Either[AmazonServiceException, ObjectMetadata]] = {
+    pipeline(request(aws)).map(response[ObjectMetadata])
+  }
+
+  def getObject(aws: GetObjectRequest): Future[Either[AmazonServiceException, S3Object]] = {
+    pipeline(request(aws)).map(response[S3Object])
+  }
+
+  def deleteObject(aws: DeleteObjectRequest): Future[Either[AmazonServiceException, Unit]] = {
+    pipeline(request(aws)).map(response[Unit])
+  }
+
+  def listObjects(aws: ListObjectsRequest): Future[Either[AmazonServiceException, ObjectListing]] = {
+    pipeline(request(aws)).map(response[ObjectListing])
+  }
 }

--- a/spray-s3/src/test/scala/com/sclasen/spray/aws/s3/S3ClientSpec.scala
+++ b/spray-s3/src/test/scala/com/sclasen/spray/aws/s3/S3ClientSpec.scala
@@ -1,15 +1,104 @@
 package com.sclasen.spray.aws.s3
 
-import org.scalatest.WordSpec
+import java.util.UUID
+import java.io.ByteArrayInputStream
+import java.nio.charset.Charset
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.collection.JavaConverters._
 
-class S3ClientSpec extends WordSepc {
+import org.scalatest.Matchers
+import org.scalatest.fixture.WordSpec
+import akka.actor.ActorSystem
+import akka.util.Timeout
+import com.amazonaws.services.s3.model._
 
-  "A S3Client" must {
+class S3ClientSpec extends WordSpec with Matchers {
 
+  val system = ActorSystem("test")
+  val props = S3ClientProps(sys.env("AWS_ACCESS_KEY_ID"), sys.env("AWS_SECRET_ACCESS_KEY"), Timeout(100 seconds), system, system)
+  val client = new S3Client(props)
+  val timeout = 10 seconds
 
+  type FixtureParam = String
 
+  def withFixture(test: OneArgTest) = {
+    val bucketName = UUID.randomUUID.toString
 
+    Await.result(client.createBucket(new CreateBucketRequest(bucketName)), timeout)
+    try {
+      test(bucketName)
+    } finally {
+      val listRequest = new ListObjectsRequest()
+      listRequest.setBucketName(bucketName)
+      val listResult = Await.result(client.listObjects(listRequest), timeout)
+      val names = listResult.right.get.getObjectSummaries.asScala.map(_.getKey)
 
+      for (name <- names) {
+        val deleteRequest = new DeleteObjectRequest(bucketName, name)
+        Await.result(client.deleteObject(deleteRequest), timeout)
+      }
 
+      Await.result(client.deleteBucket(new DeleteBucketRequest(bucketName)), timeout)
+    }
+  }
+
+  "A S3Client" when {
+    "no buckets exists" should {
+      "create, list, and delete a bucket" in { () =>
+
+        val bucketName = UUID.randomUUID.toString
+
+        val createResult = Await.result(client.createBucket(new CreateBucketRequest(bucketName)), timeout)
+        createResult shouldEqual Right(null)
+
+        val listResult = Await.result(client.listBuckets(new ListBucketsRequest), timeout)
+        listResult.right.get.map(_.getName) should contain(bucketName)
+
+        val deleteResult = Await.result(client.deleteBucket(new DeleteBucketRequest(bucketName)), timeout)
+        deleteResult shouldEqual Right(null)
+      }
+    }
+
+    "a bucket exists" should {
+      "add, get, and delete an object" in { bucketName =>
+
+        val objectName = "testObject"
+        val data = "Some test[ ] data"
+        val inputStream = new ByteArrayInputStream(data.getBytes(Charset.defaultCharset))
+        val metadata = new ObjectMetadata
+        val putResult = Await.result(client.putObject(new PutObjectRequest(bucketName, objectName, inputStream, metadata)), timeout)
+
+        assert(putResult.isRight)
+
+        val getResult = Await.result(client.getObject(new GetObjectRequest(bucketName, objectName)), timeout)
+        val is = getResult.right.get.getObjectContent
+        new String(Stream.continually(is.read).takeWhile(-1 != _).map(_.toByte).toArray, Charset.defaultCharset) shouldEqual data
+
+        val deleteResult = Await.result(client.deleteObject(new DeleteObjectRequest(bucketName, objectName)), timeout)
+        assert(deleteResult.isRight)
+      }
+
+      "add, list, and get an object containing binary" in { bucketName =>
+
+        val objectName = "testObjectBinary"
+        val data: Array[Byte] = Array(1, 2, 3, 4, 5, 6, 7, 8)
+        val inputStream = new ByteArrayInputStream(data)
+        val metadata = new ObjectMetadata
+        val putResult = Await.result(client.putObject(new PutObjectRequest(bucketName, objectName, inputStream, metadata)), timeout)
+
+        assert(putResult.isRight)
+
+        val listRequest = new ListObjectsRequest()
+        listRequest.setBucketName(bucketName)
+        val listResult = Await.result(client.listObjects(listRequest), timeout)
+
+        listResult.right.get.getObjectSummaries.get(0).getKey shouldEqual objectName
+
+        val getResult = Await.result(client.getObject(new GetObjectRequest(bucketName, objectName)), timeout)
+        val is = getResult.right.get.getObjectContent
+        Stream.continually(is.read).takeWhile(-1 != _).map(_.toByte).toArray shouldEqual data
+      }
+    }
   }
 }

--- a/spray-s3/src/test/scala/com/sclasen/spray/aws/s3/S3ClientSpec.scala
+++ b/spray-s3/src/test/scala/com/sclasen/spray/aws/s3/S3ClientSpec.scala
@@ -1,0 +1,15 @@
+package com.sclasen.spray.aws.s3
+
+import org.scalatest.WordSpec
+
+class S3ClientSpec extends WordSepc {
+
+  "A S3Client" must {
+
+
+
+
+
+
+  }
+}


### PR DESCRIPTION
I have created an AWS S3 client which allows basic operations (put, get, delete) for buckets and objects in those buckets.

The [official S3 client](https://github.com/aws/aws-sdk-java/blob/master/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java#L1087) implements a lot of request generation (and response parsing) directly as opposed to the offical DynamoDB e.g., which seems to abstract the http request generation into Marshallers. As a result lots of advanced features for those Operations need special marshaller code and are hence not supported.
