### PR TITLE
Improve s3

### DIFF
--- a/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
+++ b/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
@@ -42,6 +42,8 @@ trait SprayAWSClientProps {
   def service: String
 
   def endpoint: String
+
+  def doubleEncodeForSigning: Boolean = true
 }
 
 abstract class SprayAWSClient(props: SprayAWSClientProps) {
@@ -77,7 +79,7 @@ abstract class SprayAWSClient(props: SprayAWSClientProps) {
   val credentials = new BasicAWSCredentials(props.key, props.secret)
 
   lazy val signer: Signer = {
-    val s = new AWS4Signer()
+    val s = new AWS4Signer(props.doubleEncodeForSigning)
     s.setServiceName(props.service)
     s
   }

--- a/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
+++ b/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
@@ -5,12 +5,12 @@ import akka.io.IO
 import collection.JavaConverters._
 import com.amazonaws.auth.{ AbstractAWSSigner, Signer, AWS4Signer, BasicAWSCredentials }
 import com.amazonaws.transform.{ JsonErrorUnmarshaller, JsonUnmarshallerContext, Unmarshaller, Marshaller }
-import com.amazonaws.util.StringInputStream
 import com.amazonaws.util.json.JSONObject
 import com.amazonaws.http.{ HttpResponse => AWSHttpResponse, JsonErrorResponseHandler, JsonResponseHandler, HttpMethodName, HttpResponseHandler }
 import com.amazonaws.{ AmazonServiceException, Request, AmazonWebServiceResponse, DefaultRequest }
 import java.net.{ URLEncoder, URI }
 import java.util.{ List => JList }
+import java.io.ByteArrayInputStream
 import spray.http.HttpProtocols._
 import akka.event.LoggingAdapter
 import spray.can.Http
@@ -133,7 +133,7 @@ abstract class SprayAWSClient(props: SprayAWSClientProps) {
   def response[T](response: HttpResponse)(implicit handler: HttpResponseHandler[AmazonWebServiceResponse[T]]): Either[AmazonServiceException, T] = {
     val req = new DefaultRequest[T](props.service)
     val awsResp = new AWSHttpResponse(req, null)
-    awsResp.setContent(new StringInputStream(response.entity.asString))
+    awsResp.setContent(new ByteArrayInputStream(response.entity.data.toByteArray))
     awsResp.setStatusCode(response.status.intValue)
     awsResp.setStatusText(response.status.defaultMessage)
     if (200 <= awsResp.getStatusCode && awsResp.getStatusCode < 300) {

--- a/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
+++ b/spray-aws/src/main/scala/com/sclasen/spray/aws/SprayAWSClient.scala
@@ -114,7 +114,7 @@ abstract class SprayAWSClient(props: SprayAWSClientProps) {
     val request = if (awsReq.getContent != null) {
       val body: Array[Byte] = Stream.continually(awsReq.getContent.read).takeWhile(-1 != _).map(_.toByte).toArray
       val mediaType = MediaType.custom(contentType.getOrElse(defaultContentType))
-      HttpRequest(awsReq.getHttpMethod, path, headers(awsReq), HttpEntity(mediaType, body), `HTTP/1.1`)
+      HttpRequest(awsReq.getHttpMethod, Uri(path = Uri.Path(path)), headers(awsReq), HttpEntity(mediaType, body), `HTTP/1.1`)
     } else {
       val method: HttpMethod = awsReq.getHttpMethod
       method match {

--- a/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
+++ b/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
@@ -20,6 +20,7 @@ case class S3ClientProps(key: String, secret: String, operationTimeout: Timeout,
   factory: ActorRefFactory, endpoint: String = "https://s3.amazonaws.com")
     extends SprayAWSClientProps {
   val service = "s3"
+  override val doubleEncodeForSigning = false
 }
 
 object MarshallersAndUnmarshallers {
@@ -38,11 +39,11 @@ object MarshallersAndUnmarshallers {
       request.addHeader("x-amz-content-sha256", "required")
 
       originalRequest.getClass.getMethods.find(_.getName == "getBucketName").map { method =>
-        val bucketName = method.invoke(originalRequest)
-        request.setResourcePath(s"/${bucketName}/")
+        val bucketName: String = method.invoke(originalRequest).asInstanceOf[String]
+        request.setResourcePath(s"/${bucketName}")
 
         originalRequest.getClass.getMethods.find(_.getName == "getKey").map { method =>
-          val key = method.invoke(originalRequest)
+          val key: String = method.invoke(originalRequest).asInstanceOf[String]
           request.setResourcePath(s"/${bucketName}/${key}")
         }
       }

--- a/spray-s3/src/test/scala/com/sclasen/spray/aws/s3/S3ClientSpec.scala
+++ b/spray-s3/src/test/scala/com/sclasen/spray/aws/s3/S3ClientSpec.scala
@@ -85,7 +85,6 @@ class S3ClientSpec extends WordSpec with Matchers {
       }
 
       "add, list, and get an object containing binary" in { bucketName =>
-
         val objectName = "testObjectBinary"
         val data: Array[Byte] = Array(1, 2, 3, 4, 5, 6, 7, 8)
         val putResult = sync(client.putObject(new PutObjectRequest(bucketName, objectName, new ByteArrayInputStream(data), new ObjectMetadata)))
@@ -99,9 +98,22 @@ class S3ClientSpec extends WordSpec with Matchers {
         listResult.right.get.getObjectSummaries.get(0).getKey shouldEqual objectName
 
         val getResult = sync(client.getObject(new GetObjectRequest(bucketName, objectName)))
+      }
 
+      "put and get and object with umlauts and spaces in the name" in { bucketName =>
+        val objectName = "öbjects näme"
+        val data: Array[Byte] = Array(1, 2, 3, 4, 5, 6, 7, 8)
+        val putResult = sync(client.putObject(new PutObjectRequest(bucketName, objectName, new ByteArrayInputStream(data), new ObjectMetadata)))
+        putResult shouldBe ('right)
+
+        val getResult = sync(client.getObject(new GetObjectRequest(bucketName, objectName)))
         getResult shouldBe ('right)
         streamToBytes(getResult.right.get.getObjectContent) shouldEqual data
+      }
+
+      "get a non-existing object" in { bucketName =>
+        val getResult = sync(client.getObject(new GetObjectRequest(bucketName, "objectName")))
+        getResult shouldBe ('left)
       }
     }
   }

--- a/spray-s3/src/test/scala/com/sclasen/spray/aws/s3/S3ClientSpec.scala
+++ b/spray-s3/src/test/scala/com/sclasen/spray/aws/s3/S3ClientSpec.scala
@@ -1,9 +1,9 @@
 package com.sclasen.spray.aws.s3
 
 import java.util.UUID
-import java.io.ByteArrayInputStream
+import java.io.{ ByteArrayInputStream, InputStream }
 import java.nio.charset.Charset
-import scala.concurrent.Await
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
 
@@ -22,82 +22,86 @@ class S3ClientSpec extends WordSpec with Matchers {
 
   type FixtureParam = String
 
+  def sync[T](future: Future[T]): T = {
+    Await.result(future, timeout)
+  }
+
+  def streamToBytes(is: InputStream): Array[Byte] = {
+    Stream.continually(is.read).takeWhile(-1 != _).map(_.toByte).toArray
+  }
+
   def withFixture(test: OneArgTest) = {
     val bucketName = UUID.randomUUID.toString
 
-    Await.result(client.createBucket(new CreateBucketRequest(bucketName)), timeout)
+    sync(client.createBucket(new CreateBucketRequest(bucketName)))
+
     try {
       test(bucketName)
     } finally {
       val listRequest = new ListObjectsRequest()
       listRequest.setBucketName(bucketName)
-      val listResult = Await.result(client.listObjects(listRequest), timeout)
+      val listResult = sync(client.listObjects(listRequest))
       val names = listResult.right.get.getObjectSummaries.asScala.map(_.getKey)
 
       for (name <- names) {
-        val deleteRequest = new DeleteObjectRequest(bucketName, name)
-        Await.result(client.deleteObject(deleteRequest), timeout)
+        sync(client.deleteObject(new DeleteObjectRequest(bucketName, name)))
       }
 
-      Await.result(client.deleteBucket(new DeleteBucketRequest(bucketName)), timeout)
+      sync(client.deleteBucket(new DeleteBucketRequest(bucketName)))
     }
   }
 
   "A S3Client" when {
     "no buckets exists" should {
       "create, list, and delete a bucket" in { () =>
-
         val bucketName = UUID.randomUUID.toString
-
-        val createResult = Await.result(client.createBucket(new CreateBucketRequest(bucketName)), timeout)
+        val createResult = sync(client.createBucket(new CreateBucketRequest(bucketName)))
         createResult shouldEqual Right(null)
 
-        val listResult = Await.result(client.listBuckets(new ListBucketsRequest), timeout)
+        val listResult = sync(client.listBuckets(new ListBucketsRequest))
+        listResult should be('right)
         listResult.right.get.map(_.getName) should contain(bucketName)
 
-        val deleteResult = Await.result(client.deleteBucket(new DeleteBucketRequest(bucketName)), timeout)
+        val deleteResult = sync(client.deleteBucket(new DeleteBucketRequest(bucketName)))
         deleteResult shouldEqual Right(null)
       }
     }
 
     "a bucket exists" should {
       "add, get, and delete an object" in { bucketName =>
-
         val objectName = "testObject"
         val data = "Some test[ ] data"
         val inputStream = new ByteArrayInputStream(data.getBytes(Charset.defaultCharset))
         val metadata = new ObjectMetadata
-        val putResult = Await.result(client.putObject(new PutObjectRequest(bucketName, objectName, inputStream, metadata)), timeout)
+        val putResult = sync(client.putObject(new PutObjectRequest(bucketName, objectName, inputStream, metadata)))
+        putResult shouldBe ('right)
 
-        assert(putResult.isRight)
+        val getResult = sync(client.getObject(new GetObjectRequest(bucketName, objectName)))
+        getResult shouldBe ('right)
+        new String(streamToBytes(getResult.right.get.getObjectContent), Charset.defaultCharset) shouldEqual data
 
-        val getResult = Await.result(client.getObject(new GetObjectRequest(bucketName, objectName)), timeout)
-        val is = getResult.right.get.getObjectContent
-        new String(Stream.continually(is.read).takeWhile(-1 != _).map(_.toByte).toArray, Charset.defaultCharset) shouldEqual data
-
-        val deleteResult = Await.result(client.deleteObject(new DeleteObjectRequest(bucketName, objectName)), timeout)
-        assert(deleteResult.isRight)
+        val deleteResult = sync(client.deleteObject(new DeleteObjectRequest(bucketName, objectName)))
+        deleteResult shouldBe ('right)
       }
 
       "add, list, and get an object containing binary" in { bucketName =>
 
         val objectName = "testObjectBinary"
         val data: Array[Byte] = Array(1, 2, 3, 4, 5, 6, 7, 8)
-        val inputStream = new ByteArrayInputStream(data)
-        val metadata = new ObjectMetadata
-        val putResult = Await.result(client.putObject(new PutObjectRequest(bucketName, objectName, inputStream, metadata)), timeout)
-
-        assert(putResult.isRight)
+        val putResult = sync(client.putObject(new PutObjectRequest(bucketName, objectName, new ByteArrayInputStream(data), new ObjectMetadata)))
+        putResult shouldBe ('right)
 
         val listRequest = new ListObjectsRequest()
         listRequest.setBucketName(bucketName)
-        val listResult = Await.result(client.listObjects(listRequest), timeout)
+        val listResult = sync(client.listObjects(listRequest))
 
+        listResult shouldBe ('right)
         listResult.right.get.getObjectSummaries.get(0).getKey shouldEqual objectName
 
-        val getResult = Await.result(client.getObject(new GetObjectRequest(bucketName, objectName)), timeout)
-        val is = getResult.right.get.getObjectContent
-        Stream.continually(is.read).takeWhile(-1 != _).map(_.toByte).toArray shouldEqual data
+        val getResult = sync(client.getObject(new GetObjectRequest(bucketName, objectName)))
+
+        getResult shouldBe ('right)
+        streamToBytes(getResult.right.get.getObjectContent) shouldEqual data
       }
     }
   }


### PR DESCRIPTION
I fixed a few bugs in the s3 impelmentation, reworked the test a little bit and also had to do some minor changes in the spray-aws-client concerning encoding.

There is a new value in the props (describing whether the URL is encoded once or twice) which seems to [differ among amazon services](https://github.com/aws/aws-sdk-java/blob/master/src/main/java/com/amazonaws/auth/AWS4Signer.java#L73). Is this the right place to add such a flag?
