### PR TITLE
Add support for supplied AwsCredentialsProvider

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,9 +8,9 @@ object Build extends Build {
 
   val buildSettings = Seq(
     organization := "com.sclasen",
-    version := "0.3.5-SNAPSHOT",
-    scalaVersion := "2.11.1",
-    crossScalaVersions := Seq("2.10.4", "2.11.1"),
+    version := "0.3.6-SNAPSHOT",
+    scalaVersion := "2.11.2",
+    crossScalaVersions := Seq("2.10.4", "2.11.2"),
     scalacOptions ++= Seq("-feature", "-deprecation", "-language:implicitConversions", "-language:postfixOps"),
     resolvers ++= Seq("TypesafeMaven" at "http://repo.typesafe.com/typesafe/maven-releases",
       "whydoineedthis" at "http://repo.typesafe.com/typesafe/releases",
@@ -110,12 +110,13 @@ object Build extends Build {
   def spray:Seq[Setting[Seq[ModuleID]]] = Seq(libraryDependencies <+= scalaVersion(sprayDependency(_)))
 
   def sprayDependency(scalaVersion: String) = scalaVersion match {
-    case "2.10.4" => "io.spray" % "spray-client" % "1.3.1" % "compile"
-    case "2.11.1" => "io.spray" % "spray-client_2.11" % "1.3.1-20140423" % "compile"
+    case "2.10.4" => "io.spray" % "spray-client" % "1.3.2-20140428" % "compile"
+    case "2.11.2" => "io.spray" % "spray-client_2.11" % "1.3.1-20140423" % "compile"
   }
 
-  val aws = "com.amazonaws" % "aws-java-sdk" % "1.7.1" % "compile"
-  val akka = "com.typesafe.akka" %% "akka-actor" % "2.3.3" % "compile"
-  val akka_testkit = "com.typesafe.akka" %% "akka-testkit" % "2.3.3" % "test"
-  val scalaTest   = "org.scalatest"     %% "scalatest"   % "2.1.7" % "test"
+  val aws = "com.amazonaws" % "aws-java-sdk" % "1.8.9.1" % "compile"
+  //val aws = "com.amazonaws" % "aws-java-sdk" % "1.7.1" % "compile"
+  val akka = "com.typesafe.akka" %% "akka-actor" % "2.3.5" % "compile"
+  val akka_testkit = "com.typesafe.akka" %% "akka-testkit" % "2.3.5" % "test"
+  val scalaTest   = "org.scalatest"     %% "scalatest"   % "2.2.1" % "test"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
 
 resolvers += "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 

--- a/spray-dynamodb/src/main/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClient.scala
+++ b/spray-dynamodb/src/main/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClient.scala
@@ -1,7 +1,8 @@
 package com.sclasen.spray.aws.dynamodb
 
 import akka.actor.{ ActorRefFactory, ActorSystem }
-import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.{ BasicAWSCredentials, AWSCredentialsProvider }
+import com.amazonaws.internal.StaticCredentialsProvider
 import collection.JavaConverters._
 import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.model.transform._
@@ -14,8 +15,13 @@ import akka.util.Timeout
 import com.sclasen.spray.aws._
 import com.amazonaws.AmazonServiceException
 
-case class DynamoDBClientProps(credentialsProvider: AWSCredentialsProvider, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://dynamodb.us-east-1.amazonaws.com") extends SprayAWSClientProps {
+case class DynamoDBClientProps(credentialsProvider: AWSCredentialsProvider, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String) extends SprayAWSClientProps {
   val service = "dynamodb"
+}
+
+object DynamoDBClientProps {
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://dynamodb.us-east-1.amazonaws.com") =
+    new DynamoDBClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 
 object MarshallersAndUnmarshallers {

--- a/spray-dynamodb/src/main/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClient.scala
+++ b/spray-dynamodb/src/main/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClient.scala
@@ -1,6 +1,7 @@
 package com.sclasen.spray.aws.dynamodb
 
 import akka.actor.{ ActorRefFactory, ActorSystem }
+import com.amazonaws.auth.AWSCredentialsProvider
 import collection.JavaConverters._
 import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.model.transform._
@@ -45,7 +46,7 @@ object MarshallersAndUnmarshallers {
   implicit val getM = new GetItemRequestMarshaller()
   implicit val getU = new JsonResponseHandler(GetItemResultJsonUnmarshaller.getInstance())
 
-  val dynamoExceptionUnmarshallers = List[Unmarshaller[AmazonServiceException, JSONObject]](
+  val dynamoExceptionUnmarshallers = List[JsonErrorUnmarshaller](
     new LimitExceededExceptionUnmarshaller(),
     new InternalServerErrorExceptionUnmarshaller(),
     new ProvisionedThroughputExceededExceptionUnmarshaller(),
@@ -56,7 +57,7 @@ object MarshallersAndUnmarshallers {
 
 }
 
-class DynamoDBClient(val props: DynamoDBClientProps) extends SprayAWSClient(props) {
+class DynamoDBClient(val props: DynamoDBClientProps, overrideCredentialsProvider: Option[AWSCredentialsProvider] = None) extends SprayAWSClient(props, overrideCredentialsProvider) {
 
   import MarshallersAndUnmarshallers._
 

--- a/spray-dynamodb/src/main/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClient.scala
+++ b/spray-dynamodb/src/main/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClient.scala
@@ -14,7 +14,7 @@ import akka.util.Timeout
 import com.sclasen.spray.aws._
 import com.amazonaws.AmazonServiceException
 
-case class DynamoDBClientProps(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://dynamodb.us-east-1.amazonaws.com") extends SprayAWSClientProps {
+case class DynamoDBClientProps(credentialsProvider: AWSCredentialsProvider, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://dynamodb.us-east-1.amazonaws.com") extends SprayAWSClientProps {
   val service = "dynamodb"
 }
 
@@ -57,7 +57,7 @@ object MarshallersAndUnmarshallers {
 
 }
 
-class DynamoDBClient(val props: DynamoDBClientProps, overrideCredentialsProvider: Option[AWSCredentialsProvider] = None) extends SprayAWSClient(props, overrideCredentialsProvider) {
+class DynamoDBClient(val props: DynamoDBClientProps) extends SprayAWSClient(props) {
 
   import MarshallersAndUnmarshallers._
 

--- a/spray-dynamodb/src/main/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClient.scala
+++ b/spray-dynamodb/src/main/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClient.scala
@@ -6,9 +6,8 @@ import com.amazonaws.internal.StaticCredentialsProvider
 import collection.JavaConverters._
 import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.dynamodbv2.model.transform._
-import com.amazonaws.transform.{ JsonErrorUnmarshaller, Unmarshaller }
+import com.amazonaws.transform.{ JsonErrorUnmarshaller }
 import com.amazonaws.http.{ JsonErrorResponseHandler, JsonResponseHandler }
-import com.amazonaws.util.json.JSONObject
 import concurrent.Future
 import java.util.{ List => JList }
 import akka.util.Timeout
@@ -20,7 +19,8 @@ case class DynamoDBClientProps(credentialsProvider: AWSCredentialsProvider, oper
 }
 
 object DynamoDBClientProps {
-  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://dynamodb.us-east-1.amazonaws.com") =
+  val defaultEndpoint = "https://dynamodb.us-east-1.amazonaws.com"
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = defaultEndpoint) =
     new DynamoDBClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 

--- a/spray-dynamodb/src/test/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClientSpec.scala
+++ b/spray-dynamodb/src/test/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClientSpec.scala
@@ -1,5 +1,7 @@
 package com.sclasen.spray.aws.dynamodb
 
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.internal.StaticCredentialsProvider
 import org.scalatest.WordSpec
 import org.scalatest.Matchers
 import akka.actor.ActorSystem
@@ -13,7 +15,7 @@ class DynamoDBClientSpec extends WordSpec with Matchers {
   "A DynamoDBClient" must {
     "List tables" in {
       val system = ActorSystem("test")
-      val props = DynamoDBClientProps(sys.env("AWS_ACCESS_KEY_ID"), sys.env("AWS_SECRET_ACCESS_KEY"), Timeout(100 seconds), system, system)
+      val props = DynamoDBClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(sys.env("AWS_ACCESS_KEY_ID"), sys.env("AWS_SECRET_ACCESS_KEY"))), Timeout(100 seconds), system, system)
       val client = new DynamoDBClient(props)
       try {
         val result = Await.result(client.sendListTables(new ListTablesRequest()), 100 seconds)

--- a/spray-dynamodb/src/test/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClientSpec.scala
+++ b/spray-dynamodb/src/test/scala/com/sclasen/spray/aws/dynamodb/DynamoDBClientSpec.scala
@@ -1,7 +1,5 @@
 package com.sclasen.spray.aws.dynamodb
 
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.internal.StaticCredentialsProvider
 import org.scalatest.WordSpec
 import org.scalatest.Matchers
 import akka.actor.ActorSystem
@@ -15,7 +13,7 @@ class DynamoDBClientSpec extends WordSpec with Matchers {
   "A DynamoDBClient" must {
     "List tables" in {
       val system = ActorSystem("test")
-      val props = DynamoDBClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(sys.env("AWS_ACCESS_KEY_ID"), sys.env("AWS_SECRET_ACCESS_KEY"))), Timeout(100 seconds), system, system)
+      val props = DynamoDBClientProps(sys.env("AWS_ACCESS_KEY_ID"), sys.env("AWS_SECRET_ACCESS_KEY"), Timeout(100 seconds), system, system)
       val client = new DynamoDBClient(props)
       try {
         val result = Await.result(client.sendListTables(new ListTablesRequest()), 100 seconds)

--- a/spray-kinesis/src/main/scala/com/sclasen/spray/aws/kinesis/KinesisClient.scala
+++ b/spray-kinesis/src/main/scala/com/sclasen/spray/aws/kinesis/KinesisClient.scala
@@ -47,7 +47,7 @@ private object MarshallersAndUnmarshallers {
 
   implicit val unitResult = new JsonResponseHandler(UnitUnmarshaller)
 
-  val kinesisExceptionUnmarshallers = List[Unmarshaller[AmazonServiceException, JSONObject]](
+  val kinesisExceptionUnmarshallers = List[JsonErrorUnmarshaller](
     new InvalidArgumentExceptionUnmarshaller(),
     new LimitExceededExceptionUnmarshaller(),
     new ResourceInUseExceptionUnmarshaller(),

--- a/spray-kinesis/src/main/scala/com/sclasen/spray/aws/kinesis/KinesisClient.scala
+++ b/spray-kinesis/src/main/scala/com/sclasen/spray/aws/kinesis/KinesisClient.scala
@@ -1,24 +1,28 @@
 package com.sclasen.spray.aws.kinesis
 
-import akka.actor.{ ActorRefFactory, ActorSystem }
-import collection.JavaConverters._
-import com.amazonaws.services.kinesis.model._
-import com.amazonaws.services.kinesis.model.transform._
-import com.amazonaws.transform.JsonErrorUnmarshaller
-import concurrent.Future
-import java.util.{ List => JList }
-import akka.util.Timeout
-import com.sclasen.spray.aws._
-import com.amazonaws.services.kinesis.model.ListStreamsRequest
-import com.amazonaws.services.kinesis.model.ListStreamsResult
-import com.amazonaws.transform.Unmarshaller
-import com.amazonaws.transform.JsonUnmarshallerContext
-import com.amazonaws.AmazonServiceException
-import com.amazonaws.util.json.JSONObject
-import com.amazonaws.http.{ JsonResponseHandler, JsonErrorResponseHandler }
+import java.util.{List => JList}
 
-case class KinesisClientProps(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://kinesis.us-east-1.amazonaws.com") extends SprayAWSClientProps {
+import akka.actor.{ActorRefFactory, ActorSystem}
+import akka.util.Timeout
+import com.amazonaws.AmazonServiceException
+import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.http.{JsonErrorResponseHandler, JsonResponseHandler}
+import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.services.kinesis.model.{ListStreamsRequest, ListStreamsResult, _}
+import com.amazonaws.services.kinesis.model.transform._
+import com.amazonaws.transform.{JsonErrorUnmarshaller, JsonUnmarshallerContext, Unmarshaller}
+import com.sclasen.spray.aws._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+case class KinesisClientProps(credentialsProvider: AWSCredentialsProvider, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String) extends SprayAWSClientProps {
   val service = "kinesis"
+}
+
+object KinesisClientProps {
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://kinesis.us-east-1.amazonaws.com") =
+    new KinesisClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 
 private object MarshallersAndUnmarshallers {
@@ -69,7 +73,7 @@ private object UnitUnmarshaller extends Unmarshaller[Unit, JsonUnmarshallerConte
 
 class KinesisClient(val props: KinesisClientProps) extends SprayAWSClient(props) {
 
-  import MarshallersAndUnmarshallers._
+  import com.sclasen.spray.aws.kinesis.MarshallersAndUnmarshallers._
 
   val log = props.system.log
 

--- a/spray-kinesis/src/main/scala/com/sclasen/spray/aws/kinesis/KinesisClient.scala
+++ b/spray-kinesis/src/main/scala/com/sclasen/spray/aws/kinesis/KinesisClient.scala
@@ -21,7 +21,8 @@ case class KinesisClientProps(credentialsProvider: AWSCredentialsProvider, opera
 }
 
 object KinesisClientProps {
-  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://kinesis.us-east-1.amazonaws.com") =
+  val defaultEndpoint = "https://kinesis.us-east-1.amazonaws.com"
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = defaultEndpoint) =
     new KinesisClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 

--- a/spray-kinesis/src/main/scala/com/sclasen/spray/aws/kinesis/KinesisClient.scala
+++ b/spray-kinesis/src/main/scala/com/sclasen/spray/aws/kinesis/KinesisClient.scala
@@ -1,16 +1,16 @@
 package com.sclasen.spray.aws.kinesis
 
-import java.util.{List => JList}
+import java.util.{ List => JList }
 
-import akka.actor.{ActorRefFactory, ActorSystem}
+import akka.actor.{ ActorRefFactory, ActorSystem }
 import akka.util.Timeout
 import com.amazonaws.AmazonServiceException
-import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials}
-import com.amazonaws.http.{JsonErrorResponseHandler, JsonResponseHandler}
+import com.amazonaws.auth.{ AWSCredentialsProvider, BasicAWSCredentials }
+import com.amazonaws.http.{ JsonErrorResponseHandler, JsonResponseHandler }
 import com.amazonaws.internal.StaticCredentialsProvider
-import com.amazonaws.services.kinesis.model.{ListStreamsRequest, ListStreamsResult, _}
+import com.amazonaws.services.kinesis.model.{ ListStreamsRequest, ListStreamsResult, _ }
 import com.amazonaws.services.kinesis.model.transform._
-import com.amazonaws.transform.{JsonErrorUnmarshaller, JsonUnmarshallerContext, Unmarshaller}
+import com.amazonaws.transform.{ JsonErrorUnmarshaller, JsonUnmarshallerContext, Unmarshaller }
 import com.sclasen.spray.aws._
 
 import scala.collection.JavaConverters._

--- a/spray-kinesis/src/test/scala/com/sclasen/spray/aws/kinesis/KinesisClientSpec.scala
+++ b/spray-kinesis/src/test/scala/com/sclasen/spray/aws/kinesis/KinesisClientSpec.scala
@@ -1,7 +1,7 @@
 package com.sclasen.spray.aws.kinesis
 
 import org.scalatest.WordSpec
-import org.scalatest.matchers.MustMatchers
+import org.scalatest.MustMatchers
 import akka.actor.ActorSystem
 import akka.util.Timeout
 import concurrent.Await
@@ -14,7 +14,6 @@ import com.amazonaws.services.kinesis.model.GetRecordsRequest
 import com.amazonaws.services.kinesis.model.GetShardIteratorRequest
 import com.amazonaws.services.kinesis.model.ShardIteratorType._
 import scala.collection.JavaConversions._
-import com.amazonaws.services.kinesis.model.ShardIteratorType
 
 class KinesisClientSpec extends WordSpec with MustMatchers {
 

--- a/spray-route53/src/main/scala/com/sclasen/spray/aws/route53/Route53Client.scala
+++ b/spray-route53/src/main/scala/com/sclasen/spray/aws/route53/Route53Client.scala
@@ -17,7 +17,7 @@ import spray.http.HttpResponse
 import com.amazonaws.services.route53.internal.Route53IdRequestHandler
 import com.amazonaws.util.TimingInfo
 import scala.reflect.ClassTag
-import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials, AWS3Signer, Signer}
+import com.amazonaws.auth.{ AWSCredentialsProvider, BasicAWSCredentials, AWS3Signer, Signer }
 import com.amazonaws.services.s3.internal.AWSS3V4Signer
 
 case class Route53ClientProps(credentialsProvider: AWSCredentialsProvider, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String) extends SprayAWSClientProps {

--- a/spray-route53/src/main/scala/com/sclasen/spray/aws/route53/Route53Client.scala
+++ b/spray-route53/src/main/scala/com/sclasen/spray/aws/route53/Route53Client.scala
@@ -13,19 +13,17 @@ import com.amazonaws.services.route53.model._
 import com.amazonaws.http.{ StaxResponseHandler, DefaultErrorResponseHandler, HttpResponseHandler }
 import com.amazonaws.services.route53.model.{ ChangeResourceRecordSetsResult, ChangeResourceRecordSetsRequest }
 import scala.concurrent.Future
-import spray.http.HttpResponse
 import com.amazonaws.services.route53.internal.Route53IdRequestHandler
 import com.amazonaws.util.TimingInfo
-import scala.reflect.ClassTag
 import com.amazonaws.auth.{ AWSCredentialsProvider, BasicAWSCredentials, AWS3Signer, Signer }
-import com.amazonaws.services.s3.internal.AWSS3V4Signer
 
 case class Route53ClientProps(credentialsProvider: AWSCredentialsProvider, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String) extends SprayAWSClientProps {
   val service = "route53"
 }
 
 object Route53ClientProps {
-  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://route53.amazonaws.com") =
+  val defaultEndpoint = "https://route53.amazonaws.com"
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = defaultEndpoint) =
     new Route53ClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 

--- a/spray-route53/src/main/scala/com/sclasen/spray/aws/route53/Route53Client.scala
+++ b/spray-route53/src/main/scala/com/sclasen/spray/aws/route53/Route53Client.scala
@@ -25,7 +25,7 @@ case class Route53ClientProps(credentialsProvider: AWSCredentialsProvider, opera
 }
 
 object Route53ClientProps {
-  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://kinesis.us-east-1.amazonaws.com") =
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://route53.amazonaws.com") =
     new Route53ClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 

--- a/spray-route53/src/main/scala/com/sclasen/spray/aws/route53/Route53Client.scala
+++ b/spray-route53/src/main/scala/com/sclasen/spray/aws/route53/Route53Client.scala
@@ -2,6 +2,7 @@ package com.sclasen.spray.aws.route53
 
 import akka.util.Timeout
 import akka.actor.{ ActorRefFactory, ActorSystem }
+import com.amazonaws.internal.StaticCredentialsProvider
 import com.sclasen.spray.aws.{ SprayAWSClient, SprayAWSClientProps }
 import com.amazonaws.transform.{ Marshaller, StandardErrorUnmarshaller, Unmarshaller }
 import com.amazonaws.{ Request, AmazonWebServiceResponse, AmazonServiceException }
@@ -16,11 +17,16 @@ import spray.http.HttpResponse
 import com.amazonaws.services.route53.internal.Route53IdRequestHandler
 import com.amazonaws.util.TimingInfo
 import scala.reflect.ClassTag
-import com.amazonaws.auth.{ AWS3Signer, Signer }
+import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials, AWS3Signer, Signer}
 import com.amazonaws.services.s3.internal.AWSS3V4Signer
 
-case class Route53ClientProps(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://route53.amazonaws.com") extends SprayAWSClientProps {
+case class Route53ClientProps(credentialsProvider: AWSCredentialsProvider, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String) extends SprayAWSClientProps {
   val service = "route53"
+}
+
+object Route53ClientProps {
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://kinesis.us-east-1.amazonaws.com") =
+    new Route53ClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 
 object MarshallersAndUnmarshallers {

--- a/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
+++ b/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
@@ -23,7 +23,8 @@ case class S3ClientProps(credentialsProvider: AWSCredentialsProvider, operationT
 }
 
 object S3ClientProps {
-  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://s3.amazonaws.com") =
+  val defaultEndpoint = "https://s3.amazonaws.com"
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = defaultEndpoint) =
     new S3ClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 

--- a/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
+++ b/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
@@ -1,13 +1,13 @@
 package com.sclasen.spray.aws.s3
 
-import java.util.{List => JList}
+import java.util.{ List => JList }
 
-import akka.actor.{ActorRefFactory, ActorSystem}
+import akka.actor.{ ActorRefFactory, ActorSystem }
 import akka.util.Timeout
 import com.amazonaws.AmazonServiceException
-import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.auth.{ AWSCredentialsProvider, BasicAWSCredentials }
 import com.amazonaws.internal.StaticCredentialsProvider
-import com.amazonaws.services.s3.internal.{S3ErrorResponseHandler, S3MetadataResponseHandler, S3ObjectResponseHandler}
+import com.amazonaws.services.s3.internal.{ S3ErrorResponseHandler, S3MetadataResponseHandler, S3ObjectResponseHandler }
 import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.model.transform.Unmarshallers
 import com.sclasen.spray.aws._
@@ -30,9 +30,9 @@ object S3ClientProps {
 object MarshallersAndUnmarshallers {
 
   import com.amazonaws.http.HttpMethodName
-  import com.amazonaws.services.s3.internal.{Constants, S3XmlResponseHandler}
+  import com.amazonaws.services.s3.internal.{ Constants, S3XmlResponseHandler }
   import com.amazonaws.transform.Marshaller
-  import com.amazonaws.{AmazonWebServiceRequest, DefaultRequest, Request}
+  import com.amazonaws.{ AmazonWebServiceRequest, DefaultRequest, Request }
 
   class S3Marshaller[X <: AmazonWebServiceRequest](httpMethod: HttpMethodName)
       extends Marshaller[Request[X], X] {

--- a/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
+++ b/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
@@ -1,35 +1,38 @@
 package com.sclasen.spray.aws.s3
 
-import java.util.{ List => JList }
-import java.io.ByteArrayInputStream
-import scala.concurrent.Future
-import scala.collection.JavaConverters._
+import java.util.{List => JList}
 
+import akka.actor.{ActorRefFactory, ActorSystem}
 import akka.util.Timeout
-import akka.actor.{ ActorRefFactory, ActorSystem }
-
 import com.amazonaws.AmazonServiceException
-import com.amazonaws.http.HttpResponseHandler
+import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.services.s3.internal.{S3ErrorResponseHandler, S3MetadataResponseHandler, S3ObjectResponseHandler}
 import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.model.transform.Unmarshallers
-import com.amazonaws.services.s3.internal.{ S3ErrorResponseHandler, S3ObjectResponseHandler, S3MetadataResponseHandler }
-
 import com.sclasen.spray.aws._
 
-case class S3ClientProps(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem,
-  factory: ActorRefFactory, endpoint: String = "https://s3.amazonaws.com")
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+case class S3ClientProps(credentialsProvider: AWSCredentialsProvider, operationTimeout: Timeout, system: ActorSystem,
+  factory: ActorRefFactory, endpoint: String)
     extends SprayAWSClientProps {
   val service = "s3"
   override val doubleEncodeForSigning = false
 }
 
+object S3ClientProps {
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://kinesis.us-east-1.amazonaws.com") =
+    new S3ClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
+}
+
 object MarshallersAndUnmarshallers {
 
-  import com.amazonaws.transform.{ Marshaller, Unmarshaller }
-  import com.amazonaws.{ DefaultRequest, Request }
-  import com.amazonaws.services.s3.internal.{ Constants, S3XmlResponseHandler }
-  import com.amazonaws.{ AmazonWebServiceRequest, AmazonWebServiceResponse }
   import com.amazonaws.http.HttpMethodName
+  import com.amazonaws.services.s3.internal.{Constants, S3XmlResponseHandler}
+  import com.amazonaws.transform.Marshaller
+  import com.amazonaws.{AmazonWebServiceRequest, DefaultRequest, Request}
 
   class S3Marshaller[X <: AmazonWebServiceRequest](httpMethod: HttpMethodName)
       extends Marshaller[Request[X], X] {
@@ -110,7 +113,7 @@ object MarshallersAndUnmarshallers {
 
 class S3Client(val props: S3ClientProps) extends SprayAWSClient(props) {
 
-  import MarshallersAndUnmarshallers._
+  import com.sclasen.spray.aws.s3.MarshallersAndUnmarshallers._
 
   val log = props.system.log
   def errorResponseHandler = new S3ErrorResponseHandler

--- a/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
+++ b/spray-s3/src/main/scala/com/sclasen/spray/aws/s3/S3Client.scala
@@ -23,7 +23,7 @@ case class S3ClientProps(credentialsProvider: AWSCredentialsProvider, operationT
 }
 
 object S3ClientProps {
-  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://kinesis.us-east-1.amazonaws.com") =
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://s3.amazonaws.com") =
     new S3ClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 

--- a/spray-sqs/src/main/scala/com/sclasen/spray/aws/sqs/SQSClient.scala
+++ b/spray-sqs/src/main/scala/com/sclasen/spray/aws/sqs/SQSClient.scala
@@ -1,7 +1,7 @@
 package com.sclasen.spray.aws.sqs
 
 import akka.actor.{ ActorRefFactory, ActorSystem }
-import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.auth.{ AWSCredentialsProvider, BasicAWSCredentials }
 import com.amazonaws.internal.StaticCredentialsProvider
 
 import org.w3c.dom.Node

--- a/spray-sqs/src/main/scala/com/sclasen/spray/aws/sqs/SQSClient.scala
+++ b/spray-sqs/src/main/scala/com/sclasen/spray/aws/sqs/SQSClient.scala
@@ -1,6 +1,8 @@
 package com.sclasen.spray.aws.sqs
 
 import akka.actor.{ ActorRefFactory, ActorSystem }
+import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.internal.StaticCredentialsProvider
 
 import org.w3c.dom.Node
 
@@ -17,8 +19,13 @@ import akka.util.Timeout
 import com.sclasen.spray.aws._
 import com.amazonaws.AmazonServiceException
 
-case class SQSClientProps(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://sqs.us-east-1.amazonaws.com") extends SprayAWSClientProps {
+case class SQSClientProps(credentialsProvider: AWSCredentialsProvider, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String) extends SprayAWSClientProps {
   val service = "sqs"
+}
+
+object SQSClientProps {
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://kinesis.us-east-1.amazonaws.com") =
+    new SQSClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 
 object MarshallersAndUnmarshallers {

--- a/spray-sqs/src/main/scala/com/sclasen/spray/aws/sqs/SQSClient.scala
+++ b/spray-sqs/src/main/scala/com/sclasen/spray/aws/sqs/SQSClient.scala
@@ -24,7 +24,7 @@ case class SQSClientProps(credentialsProvider: AWSCredentialsProvider, operation
 }
 
 object SQSClientProps {
-  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://kinesis.us-east-1.amazonaws.com") =
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://sqs.us-east-1.amazonaws.com") =
     new SQSClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 

--- a/spray-sqs/src/main/scala/com/sclasen/spray/aws/sqs/SQSClient.scala
+++ b/spray-sqs/src/main/scala/com/sclasen/spray/aws/sqs/SQSClient.scala
@@ -11,7 +11,6 @@ import com.amazonaws.services.sqs.model._
 import com.amazonaws.services.sqs.model.transform._
 import com.amazonaws.transform.StandardErrorUnmarshaller
 import com.amazonaws.transform.{ VoidStaxUnmarshaller, Unmarshaller }
-import com.amazonaws.AmazonServiceException
 import com.amazonaws.http.{ StaxResponseHandler, DefaultErrorResponseHandler }
 
 import concurrent.Future
@@ -24,7 +23,8 @@ case class SQSClientProps(credentialsProvider: AWSCredentialsProvider, operation
 }
 
 object SQSClientProps {
-  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = "https://sqs.us-east-1.amazonaws.com") =
+  val defaultEndpoint = "https://sqs.us-east-1.amazonaws.com"
+  def apply(key: String, secret: String, operationTimeout: Timeout, system: ActorSystem, factory: ActorRefFactory, endpoint: String = defaultEndpoint) =
     new SQSClientProps(new StaticCredentialsProvider(new BasicAWSCredentials(key, secret)), operationTimeout, system, factory, endpoint)
 }
 


### PR DESCRIPTION
update dependencies to current versions
update signatures to support AWS SDK 1.8.x

hi @sclasen, took a quick stab at this earlier, this is probably not the most ideal way but the quickest to avoid breaking other clients. i think it would be better if it requires an AwsCredentialProvider in the constructor (as part of props? remove the key & secret from props) 
